### PR TITLE
Add portable Docker docs and helper scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,15 @@ on:
       - main
 
 jobs:
+  shell-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bash syntax check
+        run: bash -n scripts/*.sh
+
   python-ci:
     runs-on: ubuntu-latest
     defaults:

--- a/docs/docker-host-portability.md
+++ b/docs/docker-host-portability.md
@@ -1,0 +1,43 @@
+# Docker ホスト差し替えポータビリティ設計
+
+現状は **ローカル PC = Docker ホスト** として運用しますが、将来的に **リモートサーバ = Docker ホスト** へ移行しても同じコマンド体系を維持する方針を明文化します。
+
+## 基本方針
+- Docker の接続先は **Docker context** で切り替える。
+- 全ての compose 操作は `./scripts/compose.sh`（内部で `docker --context "$DOCKER_CONTEXT" compose` を呼ぶ）経由に統一。
+- **コマンドは変えずに** `DOCKER_CONTEXT` の値だけ差し替えることで、ローカルでもリモートでも同じ手順を実行できる。
+
+## Docker context の追加例（ssh 経由）
+```bash
+# リモートホストを context "remote" として登録
+docker context create remote \
+  --docker "host=ssh://<user>@<remote-host>"
+
+# 確認
+docker context ls
+```
+
+## 運用時の使い方
+```bash
+# ローカル（default context）で起動する場合
+./scripts/compose.sh up -d
+
+# リモートホストに切り替えて起動する場合
+DOCKER_CONTEXT=remote ./scripts/compose.sh up -d
+```
+- すべての compose オプションはそのまま透過的に渡せます（例: `logs`, `pull`, `down` など）。
+- context 未設定時は `default` とみなし、ローカル Docker デーモンに接続します。
+
+## 移行チェックリスト（local → remote）
+- [ ] リモートホストに Docker Engine + Compose plugin がインストールされている。
+- [ ] `docker context create` でリモートを登録し、`docker --context remote info` が成功する。
+- [ ] `.env` をリモート側にも配置（秘密は安全な経路で配布）。
+- [ ] `DOCKER_CONTEXT=remote ./scripts/compose.sh pull` が成功する。
+- [ ] `DOCKER_CONTEXT=remote ./scripts/compose.sh up -d --remove-orphans` で起動する。
+- [ ] iPhone から `http(s)://<remote-host>:8080/dev` にアクセスして `/health` `/version` が確認できる。
+- [ ] 不要になったローカルリソース（古い context、イメージ）を整理する。
+
+## ヒント
+- context 名は `remote` 以外でも任意。`DOCKER_CONTEXT` の値と一致させれば OK です。
+- SSH 秘密鍵や `.env` は Git にコミットしないでください。
+- ネットワーク遅延が大きい場合は、`logs -f` などストリーミング系操作が重くなるため、必要に応じて `--tail` を付与してください。

--- a/docs/local-dev-ubuntu24-docker.md
+++ b/docs/local-dev-ubuntu24-docker.md
@@ -1,0 +1,79 @@
+# Ubuntu 24.04 でのローカル開発用 Docker/Compose セットアップ
+
+この手順では **単一の Ubuntu 24.04 PC を Docker ホスト** として使いつつ、将来 Docker ホストを差し替えても同じコマンドで動かせる構成を整えます。スマホ（iPhone）からの確認を想定し、LAN 内の IP でアクセスする流れも記載しています。
+
+## 前提
+- Ubuntu 24.04（sudo 可能なユーザー）
+- `.env` はコミットしない。雛形として `.env.example` を利用
+- `docker-compose.yml` がリポジトリ直下にあること
+
+## Docker Engine + Compose plugin の導入（コピペ手順）
+既存の古いパッケージを削除し、Docker 公式リポジトリからインストールします。
+
+```bash
+# 1) 古いパッケージを削除
+sudo apt-get remove docker docker-engine docker.io containerd runc || true
+
+# 2) 依存とリポジトリ設定
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# 3) Docker Engine と Compose plugin をインストール
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+> sudo 無し運用は任意です。`docker` グループは実質 root 権限となるため、追加する場合はリスクを理解した上で運用してください。
+
+## デーモン確認と疎通チェック
+```bash
+# systemd でデーモン状態を確認
+sudo systemctl status docker
+
+# hello-world で疎通確認
+sudo docker run --rm hello-world
+```
+`hello-world` のメッセージが表示されれば Engine/ネットワークが正常です。
+
+## 環境変数ファイルの用意
+リポジトリ直下で `.env.example` を `.env` にコピーし、必要に応じて値を編集します。
+
+```bash
+cp .env.example .env
+```
+> `.env` は Git にコミットしないでください。`.gitignore` に登録済みです。
+
+## compose 起動（ホスト差し替え対応版）
+Docker ホストの指定を `DOCKER_CONTEXT` 環境変数に集約するため、**常に専用スクリプトを経由**します。
+
+```bash
+# 例: ローカルホストに対して起動
+./scripts/doctor.sh
+./scripts/compose.sh up -d --build
+
+# 停止
+./scripts/compose.sh down
+```
+- `DOCKER_CONTEXT` を未設定（空）の場合、`default` を利用します。
+- 将来リモートホストへ移行しても、`DOCKER_CONTEXT=remote ./scripts/compose.sh up -d` のように **環境変数を変えるだけ**で同じコマンド体系を使えます。
+
+## iPhone からの確認方法（同一 LAN を想定）
+1. Docker を動かしている PC の IP を確認: `hostname -I | awk '{print $1}'`
+2. iPhone Safari で `http://<上で確認したIP>:8080/dev` を開く。
+3. 画面に `/health` と `/version` の内容が表示されれば OK。
+
+外部公開前でも、同一 LAN 内なら IP:PORT でアクセスできます。ポートや FW 設定が閉じている場合は OS のファイアウォール設定を確認してください。
+
+## よくある詰まりと対処
+- **`docker: command not found`**: 上記のインストール手順を再実行する。
+- **`permission denied while trying to connect to the Docker daemon socket`**: `sudo docker ...` で動くか確認。sudo なし運用をしたい場合は `docker` グループに追加するが、権限リスクに注意。
+- **`hello-world` が失敗する**: `sudo systemctl status docker` でデーモン稼働を確認し、`sudo systemctl restart docker` で再起動を試す。
+- **`./scripts/compose.sh` がリモートを掴まない**: `DOCKER_CONTEXT` が意図通りか `echo $DOCKER_CONTEXT` で確認し、`docker context ls` で登録状況を確認する。
+- **アプリが外部から見えない**: `docker-compose.yml` のポート (`8080:8080`) を確認し、iPhone が同一ネットワークにいるかチェックする。

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,5 +1,7 @@
 # オペレーション（Phase1 / S1）
 
+ローカル環境セットアップ（Ubuntu 24.04）や Docker ホスト差し替えの設計は `docs/local-dev-ubuntu24-docker.md` と `docs/docker-host-portability.md` を参照してください。
+
 ## 環境変数
 - `PORT`（既定: 8080）— API の待受ポート
 - `GIT_SHA`（既定: `unknown`）— `/health` と `/version` に表示するコミット SHA
@@ -7,6 +9,7 @@
 - `APP_ENV`（既定: `dev`）— `/dev` に表示する環境ラベル
 
 `.env.example` を雛形として `.env` を用意し、秘密情報はコミットしない。実行時 `.env` は compose ファイルと同じディレクトリに置く。
+> `.env` は Git に含めないでください（`.gitignore` 済み）。必要に応じて `.env.example` をコピーして編集します。
 
 ## GitHub Secrets / Variables
 - 必須: `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,6 +6,8 @@ Phase1/S1 の iPhone-first ワークフローで、ローカルセットアッ�
 - Docker / Docker Compose が利用できること
 - Python 実行環境は不要（テスト実行時のみ必要）
 - デプロイ確認は iPhone Safari から行う
+- ローカル開発環境のセットアップは `docs/local-dev-ubuntu24-docker.md` を参照（Ubuntu 24.04 向け）
+- 将来の Docker ホスト差し替え運用は `docs/docker-host-portability.md` を参照
 
 ## 2. リポジトリ構成（抜粋）
 ```
@@ -25,12 +27,15 @@ deploy/           # サーバ用 compose/Caddy テンプレ + 手順
    - `PORT`（デフォルト 8080）
    - `APP_ENV`（`dev` / `prod` など表示用）
    - `BUILD_TIME`（任意。`/version` に表示）
+> `.env` はリポジトリにコミットしないでください（`.gitignore` に登録済み）。
 
 ## 4. ローカル実行
 ```bash
 docker compose up --build
 ```
 ブラウザで `http://localhost:8080/dev` を開き、Health/Version が表示されることを確認。
+
+`DOCKER_CONTEXT` で Docker ホストを切り替える場合は、`./scripts/compose.sh` ラッパー経由で起動してください。詳細は `docs/docker-host-portability.md` を参照。
 
 ## 5. iPhone での確認
 1. デプロイ環境の `https://<domain>/dev` を iPhone Safari で開く。

--- a/scripts/compose.sh
+++ b/scripts/compose.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR%/scripts}"
+cd "$PROJECT_ROOT"
+
+CONTEXT="${DOCKER_CONTEXT:-default}"
+exec docker --context "$CONTEXT" compose "$@"

--- a/scripts/dev-down.sh
+++ b/scripts/dev-down.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR%/scripts}"
+cd "$PROJECT_ROOT"
+
+"$PROJECT_ROOT/scripts/compose.sh" down "$@"

--- a/scripts/dev-logs.sh
+++ b/scripts/dev-logs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR%/scripts}"
+cd "$PROJECT_ROOT"
+
+"$PROJECT_ROOT/scripts/compose.sh" logs -f "$@"

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR%/scripts}"
+cd "$PROJECT_ROOT"
+
+"$PROJECT_ROOT/scripts/compose.sh" up -d --build "$@"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${SCRIPT_DIR%/scripts}"
+cd "$PROJECT_ROOT"
+
+CONTEXT="${DOCKER_CONTEXT:-default}"
+STATUS=0
+
+print_ok() {
+  printf '[OK] %s
+' "$1"
+}
+
+print_ng() {
+  printf '[NG] %s
+' "$1"
+  STATUS=1
+}
+
+print_info() {
+  printf '[INFO] %s
+' "$1"
+}
+
+if ! command -v docker >/dev/null 2>&1; then
+  print_ng "docker コマンドが見つかりません。docs/local-dev-ubuntu24-docker.md を参照してインストールしてください。"
+  echo "全てのチェックは docker が導入されてから再実行してください。"
+  exit 1
+else
+  print_ok "docker コマンドを検出しました。"
+fi
+
+if docker --context "$CONTEXT" info >/dev/null 2>&1; then
+  print_ok "docker --context \"$CONTEXT\" info が成功しました。デーモンと疎通しています。"
+else
+  print_ng "docker --context \"$CONTEXT\" info に失敗しました。Docker デーモンや context 設定を確認してください。"
+  print_info "ローカルの場合: sudo systemctl status docker / restart docker。リモートの場合: docker context ls で設定を確認。"
+fi
+
+if docker --context "$CONTEXT" compose version >/dev/null 2>&1; then
+  print_ok "docker compose plugin が利用可能です。"
+else
+  print_ng "docker compose plugin が見つからないか実行に失敗しました。インストール状態を確認してください。"
+fi
+
+if [ -f .env ]; then
+  print_ok ".env を検出しました。"
+else
+  print_ng ".env が見つかりません。必要に応じて 'cp .env.example .env' を実行し、値を設定してください。"
+fi
+
+if [ "$STATUS" -eq 0 ]; then
+  print_info "次のステップ例: ./scripts/compose.sh up -d --build でサービスを起動し、ブラウザで http://localhost:8080/dev を確認。"
+  exit 0
+else
+  echo "---"
+  print_info "問題が解決したら再度 ./scripts/doctor.sh を実行してください。"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add Ubuntu 24.04 setup guide and portability policy docs with iPhone-first checks
- introduce compose/doctor/dev helper scripts that honor DOCKER_CONTEXT for host switching
- link existing docs to the new guides and add CI bash syntax checking for scripts

## Testing
- bash -n scripts/*.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b5cb8e7d4833382f004aa1c31bc4d)