### PR TITLE
Add evidence-based project diagnosis and loop adoption plan

### DIFF
--- a/docs/diagnosis/LOOP_ADOPTION_PLAN.md
+++ b/docs/diagnosis/LOOP_ADOPTION_PLAN.md
@@ -1,0 +1,164 @@
+# LOOP_ADOPTION_PLAN
+
+## Recommended file layout
+
+```text
+/
+├─ AGENTS.md
+├─ PLANS.md
+├─ Plan.md
+├─ .agents/
+│  └─ skills/
+│     ├─ run-required-validations/
+│     │  └─ SKILL.md
+│     ├─ update-plan-and-log/
+│     │  └─ SKILL.md
+│     └─ diagnose-failures/
+│        └─ SKILL.md
+├─ docs/
+│  ├─ diagnosis/
+│  │  ├─ PROJECT_DIAGNOSIS.md
+│  │  └─ LOOP_ADOPTION_PLAN.md
+│  └─ improvement/
+│     ├─ skills.md
+│     └─ loop_requirements_checklist.md
+└─ Makefile (optional but strongly recommended)
+```
+
+## Required execution order
+
+### Canonical order (must be documented and enforced)
+1. Read `PLANS.md`.
+2. Create or update `Plan.md`.
+3. Implement scope changes (for first loop: `AGENTS.md` + docs/improvement files)。
+4. Update `docs/improvement/skills.md` (operation log).
+5. Update `docs/improvement/loop_requirements_checklist.md`.
+6. Run mandatory validations.
+7. If failure: rerun/defer policyを適用してPR本文に明記。
+
+### Enforceability strategy (docs-only)
+- `AGENTS.md` 冒頭に「`Plan.md` 更新前に必ず `PLANS.md` を読む」必須ルールを明記。
+- PR template にチェック項目追加:
+  - `[ ] PLANS.md を先に読んだ`
+  - `[ ] Plan.md を更新した`
+  - `[ ] skills.md と checklist を更新した`
+- `make loop-check`（後続導入）で上記 artefact 存在と更新時刻整合を機械検証。
+
+## Minimal `AGENTS.md` (draft)
+- 目的: repo map + 必須順序 + 禁止事項を短く正確に提供。
+- 最小項目:
+  1. Repo map（`apps/api`, `docs`, `scripts`, `.github/workflows`）
+  2. 必須順序: `PLANS.md -> Plan.md -> 実装 -> skills/checklist -> validation`
+  3. 必須検証コマンド（現状 + 代替）
+  4. 失敗分類ルール（4分類）
+  5. defer 許可条件と記録先
+
+## Minimal `PLANS.md` (draft)
+- 役割: Plan運用の「規約」だけを記述（計画本体は書かない）。
+- 必須項目:
+  - Plan.md の目的・粒度（1PR=1主目的）
+  - status 定義（todo/in_progress/done/deferred）
+  - defer の条件と期限
+  - validation 記録フォーマット
+  - `skills.md` 追記ルール
+
+## First `Plan.md` candidate
+
+### Goal
+初回 loop closure を1PRで成立させる。
+
+### Milestones
+1. `AGENTS.md` 初版作成（repo map + order + validation policy）
+2. `docs/improvement/skills.md` 初回ログ追加
+3. `docs/improvement/loop_requirements_checklist.md` 初版作成
+4. 必須検証実行・結果記録
+5. PR作成（deferがあれば理由と再実行条件を明記）
+
+### Definition of done
+- 上記3ファイルが存在し、相互参照がある
+- 必須検証結果がPR本文に記載される
+- 失敗がある場合、4分類 + rerun/defer判断を記録
+
+## First PR contents and atomicity rule
+- **Atomicity rule**: 初回PRは「loopの土台 artefact とその運用証跡」だけを含め、アプリ機能変更を混ぜない。
+- 同梱必須:
+  - `AGENTS.md`
+  - `Plan.md`（milestone付）
+  - `docs/improvement/skills.md`（初回運用ログ）
+  - `docs/improvement/loop_requirements_checklist.md`
+  - 検証結果セクション（成功/失敗分類つき）
+
+## Mandatory validation commands and rerun/defer policy
+
+### Mandatory commands (target)
+1. `make test`
+2. `python -m compileall -q app charaname_studio tests`
+3. `make loop-check`
+
+### Current-state diagnosis
+- `make test`: target未定義（missing instructions / missing docs）
+- root compileall: path不整合（code/config inconsistency）
+- `make loop-check`: target未定義（missing instructions / missing docs）
+
+### Rerun/defer policy (draft)
+- 失敗ごとに必ず次を記録:
+  - command
+  - timestamp (UTC)
+  - classification（4分類）
+  - rerun条件
+  - defer期限
+- defer許可は以下のみ:
+  - environment/setup issue
+  - flaky or unknown（ただし2回再実行後）
+- `missing instructions / missing docs` と `code/config inconsistency` は原則 defer 不可（次PRで即修正計画を必須化）。
+
+## Loop requirements checklist draft
+初回版は `docs/improvement/loop_requirements_checklist.md` に次を持つ:
+- [ ] `PLANS.md` を先に読んだ記録
+- [ ] `Plan.md` に milestone と DoD を記述
+- [ ] `AGENTS.md` に order と validation policy を記述
+- [ ] `docs/improvement/skills.md` に実行ログ追記
+- [ ] 必須3コマンドを実行し結果分類
+- [ ] defer があれば理由・期限・owner を記述
+
+## Top skill candidates
+1. `run-required-validations`
+   - 指定3コマンド実行 + 結果分類 + rerun/defer判定
+2. `update-plan-and-log`
+   - Plan.md milestone更新と `docs/improvement/skills.md` 記録を同期
+3. `loop-pr-assembly`
+   - PR本文テンプレ生成（チェックリスト、証跡、defer情報）
+
+## Promotion criteria
+- 3回以上繰り返した作業
+- 入力/出力が定型
+- 失敗分類ルールを機械化できる
+- 実行時間を有意に短縮できる
+
+## Suggested automation cadence
+- Daily: `make loop-check`（導入後）
+- Per PR: required validations + checklist更新
+- Weekly: `docs/improvement/skills.md` から skill昇格候補を棚卸し
+
+## 30 / 60 / 90 minute bootstrap plan
+
+### 0-30 min
+- `PLANS.md` と `Plan.md` の雛形作成
+- `AGENTS.md` 最小版作成（順序ルールと検証方針を明記）
+
+### 30-60 min
+- `docs/improvement/skills.md` と checklist 初版作成
+- PR template へ loop チェック項目追加
+
+### 60-90 min
+- 必須検証3コマンド実行
+- 失敗分類・rerun/defer判断記録
+- 初回 loop closure PR を作成
+
+## Minimal adoption sequence (single best path)
+1. `PLANS.md` を最初に追加（規約を固定）
+2. 同PRで `Plan.md` + `AGENTS.md` + `docs/improvement/{skills,checklist}.md` を追加
+3. その場で mandatory validation 実行
+4. 失敗分類を記録して PR を提出
+
+この順序が最小コストで効果最大。理由は、運用規約（PLANS）を先に固定することで、以降の artefact 作成と検証記録の一貫性を最初から担保できるため。

--- a/docs/diagnosis/PROJECT_DIAGNOSIS.md
+++ b/docs/diagnosis/PROJECT_DIAGNOSIS.md
@@ -1,0 +1,156 @@
+# PROJECT_DIAGNOSIS
+
+## Executive summary
+- 本リポジトリは **単一 FastAPI サービス中心の small monorepo 風構成**（`apps/api` + `deploy` + `scripts` + `docs`）で、CI は `ruff + pytest(coverage>=85) + docker smoke` まで実装済みです。
+- 一方で、Codex 自己改善ループの中核 artefact（`AGENTS.md`, `PLANS.md`, `Plan.md`, `.agents/skills`, `docs/improvement/*`）は未導入で、**初回 PR で loop を閉じるための運用ルールが欠落**しています。
+- 指定コマンド検証では、`make test` / `make loop-check` は Makefile 不在で実行不能、`python -m compileall -q app charaname_studio tests` は repo root では対象パス不一致、`apps/api` では compile 自体は成功しました。pytest は `httpx` 未導入で失敗、`scripts/doctor.sh` は Docker 未導入で失敗。
+- 結論として、**「初回 AGENTS 作成 PR で Plan 更新・skills ログ・checklist・検証まで同梱」自体は可能**ですが、実行前提（コマンド導線、PLANS 優先ルール、defer policy）を docs で先に固定しないと高確率で loop が中断します。
+
+## Repo map
+
+### Top-level
+- `apps/api/`: FastAPI アプリ本体と Python テスト。
+- `.github/workflows/`: CI/CD（CI, Docker push, Deploy, backlog issue import）。
+- `scripts/`: docker context 抽象化ラッパー、doctor、dev 補助。
+- `deploy/`: サーバ compose + Caddy + 手順。
+- `docs/`: 運用・設計・セットアップ文書。
+- `backlog/`: issue import 用のバックログ markdown。
+
+### Repo type
+- 物理的には single git repo。
+- 構造は「アプリ + インフラ + 運用 docs」を同居させた **single-repo / multi-surface**。
+
+## Tech stack and entrypoints
+- Runtime: Python 3.11 想定（`apps/api/pyproject.toml` の `target-version = "py311"`）。
+- App framework: FastAPI + Uvicorn。
+- Lint/Test: Ruff, Pytest, Pytest-cov。
+- Container: Docker, Docker Compose。
+- CI/CD: GitHub Actions。
+
+### Entrypoints
+- API app: `apps/api/app/main.py` (`app = FastAPI()`)
+- API routes: `/health`, `/version`, `/dev`, `/`
+- Container command: `uvicorn app.main:app --host 0.0.0.0 --port 8080`（compose / Dockerfile で定義）
+
+## How to run / build / test / lint / typecheck
+
+### Documented commands (current)
+- Run: `docker compose up --build`（`README.md`, `docs/usage.md`）
+- Lint/Test (apps/api):
+  - `ruff check .`
+  - `pytest -q --cov=app --cov-report=term-missing --cov-fail-under=85`
+
+### Required command checks (this diagnosis)
+1. `make test`
+   - 結果: 失敗（`No rule to make target 'test'`）
+   - 分類: **missing instructions / missing docs**（実質は build tool 定義欠落）
+   - 根因: Makefile 自体が存在しない。
+2. `python -m compileall -q app charaname_studio tests`（repo root）
+   - 結果: 終了コード 0 だが `Can't list 'app'` 等の警告。
+   - 分類: **code/config inconsistency**（指定パスが現行 repo layout と不整合）
+3. `make loop-check`
+   - 結果: 失敗（`No rule to make target 'loop-check'`）
+   - 分類: **missing instructions / missing docs**
+
+### Additional safe checks
+- `python -m compileall -q app tests`（`apps/api` で実行）: 成功
+- `python -m ruff check .`（`apps/api`）: 成功
+- `python -m pytest -q`（`apps/api`）: `httpx` 未導入で失敗
+  - 分類: **environment/setup issue**
+- `bash scripts/doctor.sh`: Docker コマンド未導入で失敗
+  - 分類: **environment/setup issue**
+
+## Architecture snapshot
+- 単一サービス API が JSON endpoint (`/health`, `/version`) と HTML Dev Portal (`/dev`) を提供。
+- Dev Portal 内の JS が同 origin で `/health` `/version` を fetch。
+- 設定は env var 由来（`PORT`, `GIT_SHA`, `BUILD_TIME`, `APP_ENV`）。
+- デプロイは GHCR push → optional SSH deploy（secrets gating）で構成。
+
+## Current quality gates
+
+### In CI
+- Shell script syntax check (`bash -n scripts/*.sh`)
+- Ruff check
+- Pytest + coverage threshold (85)
+- Docker build/run/curl smoke test
+
+### Missing/weak gates
+- `typecheck`（mypy/pyright 等）は未定義
+- `format` の公式コマンド未定義
+- loop-check 相当の「運用 artefact 完整性検証」未定義
+
+## Loop closure gaps
+1. `AGENTS.md` が未配置（root / nested ともに無し）
+2. `PLANS.md` / `Plan.md` が未配置
+3. `.agents/skills` が未配置
+4. `docs/improvement/skills.md` が未配置
+5. `docs/improvement/loop_requirements_checklist.md` が未配置
+6. `make test`, `make loop-check` 導線未提供
+7. 「validation rerun / defer policy」の明文化なし
+
+## Risk hotspots
+- **運用 docs の期待コマンドと実際の実行可能性のズレ**: repo root での検証コマンドが不整合。
+- **環境依存が強い入口**: Docker 未導入だと `scripts/doctor.sh` で止まる。
+- **Python version drift**: CI は 3.11、ローカル実行は 3.10 になりやすく再現差分の温床。
+- **docs 肥大化と鮮度劣化リスク**: `docs/phase1_issue_checklist_prompts.md` が巨大で、現在のコード範囲外の項目も多い。
+
+## Documentation audit
+
+### Good
+- README / usage / operations / architecture / deploy が揃い、Phase1 の操作導線は比較的明確。
+- Docker host portability の設計意図がドキュメント化されている。
+
+### Gaps
+- onboarding を 1 本化した「最短導線（5分起動 + 検証）」がない。
+- loop 導入 docs（PLANS first rule, Plan update protocol, defer rule）がない。
+- `docs/improvement/*` を置くディレクトリ構造が未作成。
+
+## AGENTS / PLANS / skills audit
+- `AGENTS.md`: 未検出
+- nested AGENTS: 未検出
+- `PLANS.md`: 未検出
+- `Plan.md`: 未検出
+- `.agents/skills`: 未検出
+- 判断: Codex運用の最小 map と task protocol が未定義で、自己改善ループ開始前状態。
+
+## Readiness scorecard (0-5)
+- build reproducibility: **3/5**（Docker中心で再現しやすいが、ローカル Python 版差分あり）
+- testability: **3/5**（CIは明確、ローカルは依存不足時の導線不足）
+- doc quality: **3/5**（量は十分、loop運用面が欠落）
+- observability: **2/5**（`/health` `/version` の基本のみ）
+- skillability: **2/5**（反復作業はあるが skill 管理構造未導入）
+- automation readiness: **3/5**（CI/CDあり、運用 automation は限定的）
+- loop closure readiness: **1/5**（必要 artefact 群が未配置）
+
+## Evidence appendix
+
+### Inspected files
+- `README.md`
+- `docs/architecture.md`, `docs/usage.md`, `docs/operations.md`, `docs/local-dev-ubuntu24-docker.md`, `docs/docker-host-portability.md`
+- `.github/workflows/ci.yml`, `docker.yml`, `deploy.yml`, `backlog-issue-import.yml`
+- `apps/api/app/main.py`, `apps/api/app/settings.py`
+- `apps/api/tests/*.py`, `apps/api/pyproject.toml`, `requirements*.txt`
+- `scripts/*.sh`, `docker-compose.yml`, `deploy/README.md`, `.env.example`
+
+### Executed commands
+- `make test`
+- `python -m compileall -q app charaname_studio tests` (repo root)
+- `make loop-check`
+- `python --version && pip --version`
+- `python -m compileall -q app tests` (apps/api)
+- `python -m pytest -q` (apps/api)
+- `python -m ruff check .` (apps/api)
+- `bash scripts/doctor.sh`
+- `rg --files` / `rg -n` / `find` / `sed`
+
+### Key outputs
+- `make test`: `No rule to make target 'test'`
+- `make loop-check`: `No rule to make target 'loop-check'`
+- root compileall: `Can't list 'app'`, `Can't list 'charaname_studio'`, `Can't list 'tests'`
+- pytest: `starlette.testclient module requires the httpx package`
+- doctor: `docker コマンドが見つかりません`
+
+### Unresolved unknowns
+- 実開発者環境で Python 3.11 + deps が標準化済みか
+- `make` ベース運用を今後導入する意思があるか
+- `Plan.md` の保管場所（root固定か docs 配下か）の組織合意


### PR DESCRIPTION
### Motivation
- Assess the repository's readiness for introducing a Codex self-improvement loop and identify the minimal artifacts and order required to close the first loop (PLANS.md → Plan.md → AGENTS.md / docs/improvement → validation).
- Surface gaps that will block a first PR that must include Plan updates, a skills operation log, and a loop requirements checklist.
- Produce actionable, evidence-based guidance (including verification results) so maintainers can land the loop foundation with minimal friction.

### Description
- Add `docs/diagnosis/PROJECT_DIAGNOSIS.md` containing an evidence-based current-state assessment (repo map, tech stack, quality gates, loop-closure gaps, readiness scorecard, and an evidence appendix of inspected files and command outputs). 
- Add `docs/diagnosis/LOOP_ADOPTION_PLAN.md` containing a concrete minimal adoption plan (recommended file layout, required execution order, a minimal `AGENTS.md` / `PLANS.md` / `Plan.md` draft guidance, mandatory validation commands, rerun/defer policy, skill candidates, and a 30/60/90 bootstrap plan).
- No application source changes were made; only diagnosis and planning documentation files were added under `docs/diagnosis/`.

### Testing
- Ran `make test` which failed with `No rule to make target 'test'` (classified as `missing instructions / missing docs`).
- Ran `make loop-check` which failed with `No rule to make target 'loop-check'` (classified as `missing instructions / missing docs`).
- Ran `python -m compileall -q app charaname_studio tests` at repo root which exited with warnings about missing paths (classified as `code/config inconsistency`), and ran `python -m compileall -q app tests` inside `apps/api` which succeeded.
- Ran `python -m ruff check .` inside `apps/api` which passed, and ran `python -m pytest -q` inside `apps/api` which failed due to `httpx` missing (classified as `environment/setup issue`).
- Ran `bash scripts/doctor.sh` which reported `docker` not found (classified as `environment/setup issue`).
- All verification runs and their classifications are recorded in `docs/diagnosis/PROJECT_DIAGNOSIS.md` and referenced by the adoption plan in `docs/diagnosis/LOOP_ADOPTION_PLAN.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7790c284483339e59cd61c387755e)