### PR TITLE
Translate AGENTS/PLANS/Plan docs to Japanese and refresh loop docs/logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,41 @@
 # AGENTS.md
 
-## Repo map
-- `apps/api/`: FastAPI service (`app/`) and pytest suite (`tests/`).
-- `docs/`: architecture/operations guidance and improvement logs.
-- `scripts/`: helper shell/python scripts.
-- `.github/workflows/`: CI/CD definitions.
-- `Makefile`: local validation entrypoints (`make test`, `make loop-check`).
+## リポジトリマップ
+- `apps/api/`: FastAPI サービス（`app/`）と pytest スイート（`tests/`）。
+- `docs/`: アーキテクチャ/運用ガイドと改善ログ。
+- `scripts/`: 補助シェル/Python スクリプト。
+- `.github/workflows/`: CI/CD 定義。
+- `Makefile`: ローカル検証エントリーポイント（`make test`, `make loop-check`）。
 
-## Mandatory execution order (loop protocol)
-1. Read `AGENTS.md` and then **`PLANS.md`**.
-2. Create/update `Plan.md` using `PLANS.md` rules.
-3. Implement minimal scoped changes.
-4. Update `docs/improvement/skills.md` and `docs/improvement/loop_requirements_checklist.md`.
-5. Run required validations and record outcomes in `Plan.md`.
+## 必須実行順序（ループプロトコル）
+1. `AGENTS.md` を読み、その後に **`PLANS.md`** を読む。
+2. `PLANS.md` のルールに従って `Plan.md` を作成/更新する。
+3. スコープを最小化した変更を実装する。
+4. `docs/improvement/skills.md` と `docs/improvement/loop_requirements_checklist.md` を更新する。
+5. 必須検証を実行し、結果を `Plan.md` に記録する。
 
-## Required validation commands
+## 必須検証コマンド
 - `make test`
 - `python -m compileall -q app charaname_studio tests`
 - `make loop-check`
 
-Run `python -m compileall -q app charaname_studio tests` from `apps/api/` so the expected paths resolve.
+期待されるパスが解決されるよう、`python -m compileall -q app charaname_studio tests` は `apps/api/` から実行すること。
 
-## Validation failure categories (must log in `Plan.md`)
+## 検証失敗カテゴリ（`Plan.md` への記録必須）
 1. `code_or_test_failure`
 2. `environment_or_setup_issue`
 3. `missing_instructions_or_docs`
 4. `code_config_inconsistency`
 
-## Stop-and-fix / defer rule
-- Default: stop and fix, then rerun the same command.
-- Defer allowed only for `environment_or_setup_issue` that cannot be resolved in this PR.
-- Every defer must include reason, unblock condition, and owner in `Plan.md`.
+## 停止して修正 / 保留ルール
+- デフォルト: 停止して修正し、同じコマンドを再実行する。
+- 保留を許可するのは、この PR で解決できない `environment_or_setup_issue` のみ。
+- すべての保留には、`Plan.md` に理由・解除条件・担当者を含めること。
 
-## Done definition for loop/bootstrap PRs
-A PR that creates/updates `AGENTS.md` must also update, in the same PR:
+## ループ/ブートストラップ PR の完了定義
+`AGENTS.md` を作成/更新する PR は、同じ PR 内で次も更新すること:
 - `PLANS.md`
 - `Plan.md`
 - `docs/improvement/skills.md`
 - `docs/improvement/loop_requirements_checklist.md`
-- validation logs for the 3 required commands.
+- 3 つの必須コマンドの検証ログ

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,40 +1,40 @@
 # PLANS.md
 
-`Plan.md` operational standard for this repository.
+このリポジトリにおける `Plan.md` の運用標準。
 
-## Order rule
-- Always read this file before creating or editing `Plan.md`.
+## 順序ルール
+- `Plan.md` を作成または編集する前に、常にこのファイルを読むこと。
 
-## Required sections in `Plan.md`
+## `Plan.md` の必須セクション
 1. Goal
 2. Non-goals
-3. Milestones (small, testable units)
-4. Acceptance criteria (per milestone)
-5. Validation commands (per milestone)
-6. Status (todo / in_progress / done / deferred)
-7. Validation result log (`command`, `exit code`, `summary`, `rerun`)
-8. Defer log (`reason`, `unblock condition`, `owner`)
+3. Milestones（小さく、テスト可能な単位）
+4. Acceptance criteria（マイルストーンごと）
+5. Validation commands（マイルストーンごと）
+6. Status（todo / in_progress / done / deferred）
+7. Validation result log（`command`, `exit code`, `summary`, `rerun`）
+8. Defer log（`reason`, `unblock condition`, `owner`）
 9. Decision log
 10. Current status
 11. Next action
 
-## Milestone granularity
-- Prefer one milestone per reviewable change set.
-- Keep each milestone independently verifiable.
+## マイルストーン粒度
+- レビュー可能な変更セットごとに、1 マイルストーンを基本とする。
+- 各マイルストーンを独立して検証可能に保つ。
 
-## Validation writing standard
-- Record exact command text.
-- Record UTC timestamp and exit code.
-- If failed, apply stop-and-fix and rerun.
+## 検証記載標準
+- 正確なコマンド文字列を記録する。
+- UTC タイムスタンプと終了コードを記録する。
+- 失敗した場合は、停止して修正し、再実行する。
 
-## Stop-and-fix and rerun
-- Do not proceed to next milestone while required validation is failing.
-- Rerun the same command after fixes and log both attempts.
+## 停止して修正・再実行
+- 必須検証が失敗している間は、次のマイルストーンに進まない。
+- 修正後に同じコマンドを再実行し、両方の試行を記録する。
 
-## Defer policy
-- Allowed only when blocked by environment/setup constraints.
-- Must include concrete unblock condition and follow-up action.
+## 保留ポリシー
+- 環境/セットアップ制約でブロックされた場合にのみ許可。
+- 具体的な解除条件とフォローアップアクションを必ず含める。
 
-## Living document principle
-- `Plan.md` must reflect current reality, not intent only.
-- Update `Current status` and `Next action` at the end of each loop.
+## リビングドキュメント原則
+- `Plan.md` は意図だけでなく、現在の実態を反映しなければならない。
+- 各ループの最後に `Current status` と `Next action` を更新する。

--- a/Plan.md
+++ b/Plan.md
@@ -1,45 +1,45 @@
 # Plan.md
 
 ## Goal
-Execute a deep technical due diligence investigation and capture verifiable repository maturity/runability conclusions with loop evidence.
+詳細な技術デューデリジェンス調査を実施し、ループ証跡とともに検証可能なリポジトリ成熟度/実行可能性の結論を記録する。
 
 ## Non-goals
-- Feature development in FastAPI endpoints.
-- CI architecture redesign.
-- Runtime load/performance benchmarking.
+- FastAPI エンドポイントの機能開発。
+- CI アーキテクチャの再設計。
+- 実行時負荷/性能ベンチマーク。
 
 ## Milestones
 
-### M1. Add loop foundation artifacts
+### M1. ループ基盤アーティファクトの追加
 - Acceptance criteria:
-  - `AGENTS.md`, `PLANS.md`, `Plan.md`, `docs/improvement/skills.md`, `docs/improvement/loop_requirements_checklist.md` exist and cross-reference loop process.
+  - `AGENTS.md`, `PLANS.md`, `Plan.md`, `docs/improvement/skills.md`, `docs/improvement/loop_requirements_checklist.md` が存在し、ループプロセスを相互参照している。
 - Validation commands:
   - `make loop-check`
 - Status: done
 
-### M2. Add reusable validation skill candidate
+### M2. 再利用可能な検証スキル候補の追加
 - Acceptance criteria:
-  - `.agents/skills/run-required-validations/SKILL.md` exists with trigger/non-trigger, IO, workflow, and success/failure conditions.
-  - lightweight eval prompt set exists.
+  - `.agents/skills/run-required-validations/SKILL.md` が存在し、トリガー/非トリガー、入出力、ワークフロー、成功/失敗条件を含む。
+  - 軽量な eval プロンプトセットが存在する。
 - Validation commands:
   - `make loop-check`
 - Status: done
 
-### M3. Run required validations and synchronize logs
+### M3. 必須検証の実行とログ同期
 - Acceptance criteria:
-  - `make test`, `python -m compileall -q app charaname_studio tests`, `make loop-check` executed.
-  - Results are mirrored in this file and final report.
+  - `make test`, `python -m compileall -q app charaname_studio tests`, `make loop-check` を実行済み。
+  - 結果がこのファイルと最終レポートに反映されている。
 - Validation commands:
   - `make test`
   - `python -m compileall -q app charaname_studio tests`
   - `make loop-check`
 - Status: done
 
-### M4. Perform repository due diligence with code-first evidence
+### M4. コード一次証跡によるリポジトリデューデリジェンス
 - Acceptance criteria:
-  - Investigate repository purpose, architecture, execution flows, feature status, and runability using concrete files/commands.
-  - Explicitly identify docs/code mismatches and uncertain runtime unknowns.
-  - Produce structured final report with evidence-backed conclusions.
+  - リポジトリの目的、アーキテクチャ、実行フロー、機能状態、実行可能性を具体的なファイル/コマンドで調査する。
+  - ドキュメント/コード不一致と、実行時の未確定事項を明示的に特定する。
+  - 証跡に基づく結論を持つ構造化された最終レポートを作成する。
 - Validation commands:
   - `make test`
   - `cd apps/api && python -m compileall -q app charaname_studio tests`
@@ -49,32 +49,42 @@ Execute a deep technical due diligence investigation and capture verifiable repo
 ## Validation result log
 | UTC timestamp | Command | Exit code | Summary | Rerun |
 |---|---|---:|---|---|
-| 2026-03-28T06:54:11Z | `make test` | 0 | pytest + coverage gate passed via `apps/api` (8 passed, 100% coverage). | no |
-| 2026-03-28T06:54:18Z | `cd apps/api && python -m compileall -q app charaname_studio tests` | 0 | compileall returned success but printed `Can't list 'charaname_studio'` warning. | yes |
-| 2026-03-28T06:54:43Z | `cd apps/api && python -m compileall -q app charaname_studio tests` | 0 | re-run after adding `apps/api/charaname_studio/__init__.py`; warning removed. | no |
-| 2026-03-28T06:54:50Z | `make loop-check` | 0 | required loop artifacts and ordering docs detected. | no |
-| 2026-03-28T07:16:23Z | `make test` | 2 | failed before investigation due to missing `httpx` in active Python environment (`RuntimeError` from `starlette.testclient`). Classified as `environment_or_setup_issue`. | yes |
-| 2026-03-28T07:17:02Z | `python -m pip install -r apps/api/requirements.txt -r apps/api/requirements-dev.txt` | 0 | installed missing test/runtime dependencies (`httpx`, `pytest-cov`, transitive packages). | no |
-| 2026-03-28T07:17:31Z | `make test` | 0 | pytest and coverage gate passed (8 passed, 100% coverage). | no |
-| 2026-03-28T07:17:33Z | `cd apps/api && python -m compileall -q app charaname_studio tests` | 0 | compileall succeeded with no warnings. | no |
-| 2026-03-28T07:17:35Z | `make loop-check` | 0 | loop artifact integrity check passed. | no |
-| 2026-03-28T07:21:45Z | `make test` | 0 | post-documentation-change rerun passed (8 passed, 100% coverage). | no |
-| 2026-03-28T07:21:48Z | `cd apps/api && python -m compileall -q app charaname_studio tests` | 0 | post-documentation-change rerun succeeded. | no |
-| 2026-03-28T07:21:51Z | `make loop-check` | 0 | post-documentation-change rerun passed. | no |
+| 2026-03-28T06:54:11Z | `make test` | 0 | `apps/api` 経由で pytest + カバレッジゲートが成功（8 passed, 100% coverage）。 | no |
+| 2026-03-28T06:54:18Z | `cd apps/api && python -m compileall -q app charaname_studio tests` | 0 | compileall は成功終了したが、`Can't list 'charaname_studio'` 警告を出力。 | yes |
+| 2026-03-28T06:54:43Z | `cd apps/api && python -m compileall -q app charaname_studio tests` | 0 | `apps/api/charaname_studio/__init__.py` 追加後の再実行で警告が解消。 | no |
+| 2026-03-28T06:54:50Z | `make loop-check` | 0 | 必須ループアーティファクトと順序ドキュメントを検出。 | no |
+| 2026-03-28T07:16:23Z | `make test` | 2 | 調査前にアクティブな Python 環境で `httpx` 不足により失敗（`starlette.testclient` から `RuntimeError`）。`environment_or_setup_issue` に分類。 | yes |
+| 2026-03-28T07:17:02Z | `python -m pip install -r apps/api/requirements.txt -r apps/api/requirements-dev.txt` | 0 | 不足していたテスト/実行時依存（`httpx`, `pytest-cov`, 推移的依存）をインストール。 | no |
+| 2026-03-28T07:17:31Z | `make test` | 0 | pytest とカバレッジゲートが成功（8 passed, 100% coverage）。 | no |
+| 2026-03-28T07:17:33Z | `cd apps/api && python -m compileall -q app charaname_studio tests` | 0 | compileall が警告なしで成功。 | no |
+| 2026-03-28T07:17:35Z | `make loop-check` | 0 | ループアーティファクト整合性チェックが成功。 | no |
+| 2026-03-28T07:21:45Z | `make test` | 0 | ドキュメント変更後の再実行が成功（8 passed, 100% coverage）。 | no |
+| 2026-03-28T07:21:48Z | `cd apps/api && python -m compileall -q app charaname_studio tests` | 0 | ドキュメント変更後の再実行が成功。 | no |
+| 2026-03-28T07:21:51Z | `make loop-check` | 0 | ドキュメント変更後の再実行が成功。 | no |
+
+| 2026-03-28T09:20:41Z | `make test` | 2 | アクティブな Python 環境で `httpx` 不足のため `starlette.testclient` が `RuntimeError` を送出し失敗。`environment_or_setup_issue` に分類。 | yes |
+| 2026-03-28T09:21:02Z | `python -m pip install -r apps/api/requirements.txt -r apps/api/requirements-dev.txt` | 0 | 不足依存（`httpx`, `pytest-cov` など）をインストールして環境を修復。 | no |
+| 2026-03-28T09:21:31Z | `make test` | 0 | 翻訳変更後の再実行で pytest とカバレッジゲートが成功（8 passed, 100% coverage）。 | no |
+| 2026-03-28T09:22:10Z | `cd apps/api && python -m compileall -q app charaname_studio tests` | 0 | 翻訳変更後の compileall が警告なしで成功。 | no |
+| 2026-03-28T09:22:25Z | `make loop-check` | 0 | 翻訳変更後の loop-check が成功。 | no |
+
+| 2026-03-28T09:24:40Z | `make test` | 0 | `docs/improvement` 更新後の再実行で pytest とカバレッジゲートが成功（8 passed, 100% coverage）。 | no |
+| 2026-03-28T09:24:46Z | `cd apps/api && python -m compileall -q app charaname_studio tests` | 0 | `docs/improvement` 更新後の compileall が成功。 | no |
+| 2026-03-28T09:24:52Z | `make loop-check` | 0 | `docs/improvement` 更新後の loop-check が成功。 | no |
 
 ## Defer log
-- None.
+- なし。
 
 ## Decision log
-- Read order applied: `AGENTS.md` -> `PLANS.md` -> `Plan.md` updates.
-- Added root `Makefile` + `scripts/loop_check.py` to make required validations executable and repeatable.
-- Added `apps/api/charaname_studio/__init__.py` so required compileall command resolves all expected paths cleanly.
-- Promoted one high-reuse workflow (`run-required-validations`) and left broader orchestration in docs.
-- For this loop, treated docs as non-authoritative and validated claims against code/tests/workflows/scripts before concluding maturity.
-- Resolved one `environment_or_setup_issue` (missing local dependency set) then reran required validations per stop-and-fix policy.
+- 読み取り順序 `AGENTS.md` -> `PLANS.md` -> `Plan.md` 更新を適用。
+- 必須検証を実行可能かつ反復可能にするため、ルート `Makefile` と `scripts/loop_check.py` を追加。
+- 必須 compileall コマンドで想定パスをクリーンに解決できるよう `apps/api/charaname_studio/__init__.py` を追加。
+- 高再利用ワークフロー 1 件（`run-required-validations`）を昇格し、より広いオーケストレーションはドキュメントに残した。
+- このループではドキュメントを非権威と見なし、成熟度を結論づける前にコード/テスト/ワークフロー/スクリプトに対して主張を検証した。
+- `environment_or_setup_issue` 1 件（ローカル依存セット不足）を解消し、停止して修正ポリシーに従って必須検証を再実行。
 
 ## Current status
-Due diligence investigation loop is complete; required validations passed after one environment fix and rerun.
+指定された 3 ファイル（`AGENTS.md`, `PLANS.md`, `Plan.md`）の日本語翻訳を完了し、関連改善ログ更新後も必須検証 3 コマンドが成功。
 
 ## Next action
-Prioritize next PRs that either (a) harden `/dev` access controls for production or (b) add persistence/business functionality beyond current diagnostics endpoints.
+必要に応じて `docs/improvement/` 配下ドキュメントの言語統一方針（英語/日本語）を次 PR で決定する。

--- a/docs/improvement/loop_requirements_checklist.md
+++ b/docs/improvement/loop_requirements_checklist.md
@@ -17,3 +17,8 @@
 - `make test` initially failed with missing `httpx` in the active Python environment.
 - Failure category applied: `environment_or_setup_issue`.
 - Resolution used stop-and-fix: installed `apps/api` dependencies, then reran all required validations successfully.
+
+## Latest loop notes (2026-03-28 translation update)
+- Translated `AGENTS.md`, `PLANS.md`, and `Plan.md` into Japanese while preserving loop structure.
+- `make test` failed once due to missing `httpx`; categorized as `environment_or_setup_issue`.
+- Applied stop-and-fix by installing `apps/api` dependencies and reran required validations successfully.

--- a/docs/improvement/skills.md
+++ b/docs/improvement/skills.md
@@ -57,3 +57,29 @@
 - Promote judgment: promote
 - Reason:
   - 調査観点と検証手順が定型化でき、再現性の高い監査プロセスとして使えるため。
+
+## 2026-03-28 — core loop documents Japanese translation
+- Trigger / 課題:
+  - ユーザー要求により `AGENTS.md` / `PLANS.md` / `Plan.md` を日本語化する必要があった。
+- Effective workflow / 有効だった手順:
+  1. 3ファイルの構造を維持したまま逐次翻訳。
+  2. 用語（Goal/Non-goals/Milestones など）は既存運用との互換性を優先して必要箇所を英語のまま維持。
+  3. required validations を実行し、環境エラー発生時は stop-and-fix で依存を補完して再実行。
+- Commands used:
+  - `make test`
+  - `python -m pip install -r apps/api/requirements.txt -r apps/api/requirements-dev.txt`
+  - `cd apps/api && python -m compileall -q app charaname_studio tests`
+  - `make loop-check`
+- Inputs / Outputs:
+  - Input: 既存英語ベースのループ運用ドキュメント。
+  - Output: 日本語化された 3 ファイル + 検証ログ更新。
+- Success criteria:
+  - 対象3ファイルが日本語として読める。
+  - required validations 3件が最終的に成功。
+- Failure modes:
+  - 開発環境依存（`httpx` 未導入）で `make test` が失敗。
+- Reuse signals:
+  - 将来の多言語ドキュメント整備 PR で同手順を再利用可能。
+- Promote judgment: promote
+- Reason:
+  - 翻訳作業でもループ規約（検証・ログ）を崩さず適用できることを確認できたため。


### PR DESCRIPTION
### Motivation
- Localize the repository's core loop planning documentation into Japanese while preserving the existing loop protocol, validation commands, and operational semantics.

### Description
- Translated `AGENTS.md`, `PLANS.md`, and `Plan.md` into Japanese while keeping structure, section headings, and `Plan.md` validation conventions intact.
- Updated `docs/improvement/skills.md` with a translation-loop operation log and appended translation notes to `docs/improvement/loop_requirements_checklist.md`. 
- Synchronized `Plan.md` validation result log and `Current status`/`Next action` to reflect the translation work and verification runs. 
- Ensured the docs still reference the required validation commands and run locations (e.g., compileall run from `apps/api`).

### Testing
- Ran `make test`, which initially failed due to a missing `httpx` dependency, then ran `python -m pip install -r apps/api/requirements.txt -r apps/api/requirements-dev.txt` and re-ran `make test`, which passed (8 passed, 100% coverage). 
- Ran `cd apps/api && python -m compileall -q app charaname_studio tests` from `apps/api`, which passed with no warnings. 
- Ran `make loop-check`, which returned `OK`.
- All required validations (`make test`, `python -m compileall -q app charaname_studio tests` from `apps/api`, and `make loop-check`) completed successfully after the stop-and-fix step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c79d9157b08333a2dea72b8d60b85b)